### PR TITLE
Fixing incorrect opcode in 0x00E6

### DIFF
--- a/world/server/0x00E6/README.md
+++ b/world/server/0x00E6/README.md
@@ -5,7 +5,7 @@
 | **Command Name**          | `(Unknown)` |
 | **Client Handler**        | `(Unknown)` |
 | **Direction**             | `S -> C` |
-| **OpCode**                | `0x00F6` |
+| **OpCode**                | `0x00E6` |
 | **Size**                  | `(varies)` |
 
 ## Description


### PR DESCRIPTION
I noticed that the internal OpCode field for 0x00E6 was pointing at 0x00F6.

This should correct that. 