### PR TITLE
Fix broken table formatting on State field description for packet 0x0106

### DIFF
--- a/world/server/0x0106/README.md
+++ b/world/server/0x0106/README.md
@@ -53,7 +53,7 @@ _You can find more information about the header fields here: [**Header**](/world
 _The state of the purchase._
 
 | State | Name | Purpose |
-| --- | --- |
+| --- | --- | ---
 | `0` | `GP_BAZAAR_BUY_STATE_OK`    | _The purchase was successful._ |
 | `1` | `GP_BAZAAR_BUY_STATE_ERR`   | _There was an error attempting the purchase._ |
 


### PR DESCRIPTION
I noticed that packet [0x0106](https://github.com/atom0s/XiPackets/tree/main/world/server/0x0106) had broken table formatting when describing the State field.

This should correct for that. I tested it in a markdown previewer to be sure, before submitting, and you can see a live render [here](https://github.com/StabbyCutyou/XiPackets/blob/79f9a17fb9aa83a2caeeeeeca19651347f7340fe/world/server/0x0106/README.md)